### PR TITLE
Fix wrong path to text files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,8 +231,8 @@ endif ()
 
 set(
         data_files_to_update
-        ${build_dir}/data/splash.txt
-        ${build_dir}/data/versions.txt
+        ${source_dir}/../data/splash.txt
+        ${source_dir}/../data/versions.txt
 )
 foreach (data_file ${data_files_to_update})
     file(READ ${data_file} content)


### PR DESCRIPTION
Seen when using a separated build directory:

    $ mkdir _build
    $ cd _build
    $ cmake ..

    -- Build type set to 'Release'
    ...
    -- Detecting CXX compile features - done
    CMake Error at CMakeLists.txt:238 (file):
      file failed to open for reading (No such file or directory):

        /tmp/git/umoria/umoria/data/splash.txt


    CMake Error at CMakeLists.txt:238 (file):
      file failed to open for reading (No such file or directory):

        /tmp/git/umoria/umoria/data/versions.txt


    -- NOTE: Configuring build for macOS/Linux release...
    -- Looking for wsyncup in /usr/lib64/libcurses.so
    -- Looking for wsyncup in /usr/lib64/libcurses.so - found
    -- Looking for cbreak in /usr/lib64/libncurses.so
    -- Looking for cbreak in /usr/lib64/libncurses.so - found
    -- Found Curses: /usr/lib64/libncurses.so
    -- Configuring incomplete, errors occurred!
    See also "/tmp/git/umoria/_build/CMakeFiles/CMakeOutput.log".

Bug first seen in version e73316cfb30d729019e7dc31515d26bc523be57f.    

Bug last seen in version 0403ba0376b51e43942b0802117927512256070d, 