### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "bash"
+run = "cmake . && make && make install && cd umoria && ./umoria"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Umoria
 
+[![Run on Repl.it](https://repl.it/badge/github/dungeons-of-moria/umoria)](https://repl.it/github/dungeons-of-moria/umoria)
 _The Dungeons of Moria_ is a single player dungeon simulation originally
 written by Robert Alan Koeneke, with v1.0 released in 1983. The game was
 originally written in VMS Pascal before being ported to the C language and


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@josephescamilla/umoria-5).