### PR TITLE
CMakeLists: simplify slightly and allow out-of-source builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,3 @@ endif ()
 
 include_directories(${CURSES_INCLUDE_DIR})
 target_link_libraries(umoria ${CURSES_LIBRARIES})
-
-# Build and install the umoria binary
-install(TARGETS umoria DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,8 +178,6 @@ set(
         ${PROJECT_SOURCE_DIR}/data/help_wizard.txt
         ${PROJECT_SOURCE_DIR}/data/rl_help.txt
         ${PROJECT_SOURCE_DIR}/data/rl_help_wizard.txt
-        ${PROJECT_SOURCE_DIR}/data/splash.txt
-        ${PROJECT_SOURCE_DIR}/data/versions.txt
         ${PROJECT_SOURCE_DIR}/data/welcome.txt
         ${PROJECT_SOURCE_DIR}/data/death_tomb.txt
         ${PROJECT_SOURCE_DIR}/data/death_royal.txt
@@ -231,14 +229,11 @@ endif ()
 
 set(
         data_files_to_update
-        ${build_dir}/data/splash.txt
-        ${build_dir}/data/versions.txt
+        data/splash.txt
+        data/versions.txt
 )
 foreach (data_file ${data_files_to_update})
-    file(READ ${data_file} content)
-    string(REGEX REPLACE "{{ CURRENT_VERSION }}" "${umoria_version}" content "${content}")
-    string(REGEX REPLACE "{{ RELEASE_DATE }}" "${current_date}" content "${content}")
-    file(WRITE ${data_file} ${content})
+    configure_file(${data_file}.in ${build_dir}/${data_file})
 endforeach ()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,12 +164,8 @@ set(
 set(build_dir "umoria")
 set(data_dir "${build_dir}/data")
 
-file(MAKE_DIRECTORY ${build_dir})
-file(MAKE_DIRECTORY ${data_dir})
 
-set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR})
 set(EXECUTABLE_OUTPUT_PATH ${build_dir})
-set(RUNTIME_OUTPUT_DIRECTORY ${build_dir})
 
 # Core game data files
 set(
@@ -269,4 +265,4 @@ include_directories(${CURSES_INCLUDE_DIR})
 target_link_libraries(umoria ${CURSES_LIBRARIES})
 
 # Build and install the umoria binary
-install(TARGETS umoria DESTINATION ${build_dir})
+install(TARGETS umoria DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -49,16 +49,25 @@ require these along with `CMake` and the C++ build tools for your system.
 
 ### macOS and Linux
 
-At the command prompt type the following:
+You can do an in-source build by going to the umoria folder in a command prompt
+and then type:
 
 ```
   $ cmake .
   $ make
-  $ make install
 ```
 
-A `umoria` directory will be created containing the game binary and data files,
-which you can then move to your `home` directory, or other location.
+If you would rather do an out-of-source build you can type:
+
+```
+  $ mkdir build && cd build
+  $ cmake ..
+  $ make
+```
+
+A `umoria` directory will be created in the current directory containing the
+game binary and data files, which you can then move to your `home` directory,
+or another location.
 
 
 ### Windows
@@ -77,7 +86,15 @@ to `MINGW=`:
 ```
   $ MINGW=mingw64 cmake .
   $ make
-  $ make install
+```
+
+Or, if you want to do an out of source build, type
+
+```
+  $ mkdir build
+  $ cd build
+  $ MINGW=mingw64 cmake ..
+  $ make
 ```
 
 As with the macOS/Linux builds, the files will be installed into a `umoria`

--- a/data/splash.txt.in
+++ b/data/splash.txt.in
@@ -10,7 +10,7 @@
              ##     ##   ##     ##   ##    ##     ##    ##     ##
              ##     ##    #######    ##     ##   ####   ##     ##
 
-                                Umoria {{ CURRENT_VERSION }}
+                                Umoria ${umoria_version}
 
 
 

--- a/data/versions.txt.in
+++ b/data/versions.txt.in
@@ -1,4 +1,4 @@
-                          Umoria {{ CURRENT_VERSION }}  ({{ RELEASE_DATE }})
+                          Umoria ${umoria_version}  (${current_date})
 
 Previous major releases:
 


### PR DESCRIPTION
Hi,

This PR addresses the same issue as https://github.com/dungeons-of-moria/umoria/pull/21 and fully allows for out-of-source builds. Replacing `READ`, `STRING_REPLACE` and `WRITE` with `configure_file` also shortens the CMakeLists slightly.

It also fixes a weird issue that only seem to occur when building for some platforms (cross-compiling for android with ninja) where `install(TARGETS umoria DESTINATION ${build_dir})` (i.e `install(TARGETS umoria DESTINATION umoria)`) ends up deleting umoria, due to the target and destination being the same (I think).

Everything behaves as before when doing in-src (`cmake .`) builds, out-of-src (`cmake ..`) builds, and when cross compiling. I haven't tested on windows though.

Let me know if I can improve something or explain something better!