### PR TITLE
Fix macOS/Xcode 12.5.1 struct linkage errors

### DIFF
--- a/src/game.h
+++ b/src/game.h
@@ -32,7 +32,7 @@ enum class Screen {
     Wrong,
 };
 
-typedef struct {
+typedef struct Game {
     uint32_t magic_seed = 0; // Seed for initializing magic items (Potions, Wands, Staves, Scrolls, etc.)
     uint32_t town_seed = 0;  // Seed for town generation
 

--- a/src/player.h
+++ b/src/player.h
@@ -45,7 +45,7 @@ constexpr uint8_t PLAYER_NAME_SIZE = 27;
 typedef const char *ClassRankTitle_t;
 
 // Player_t contains everything to be known about our player character
-typedef struct {
+typedef struct Player {
     struct {
         char name[PLAYER_NAME_SIZE];    // Name of character
         bool gender;                    // Gender of character (Female = 0, Male = 1)


### PR DESCRIPTION
Fix the `anonymous non-C-compatible type given name for linkage purposes by typedef declaration; add a tag name here [-Werror,-Wnon-c-typedef-for-linkage]` error encountered when compiling on macOS using Xcode 12.5.1 (clang 12.0.5). The quick fix for me was to remove the anonymous nature of these two structs, e.g., `typedef struct Game { … } Game_t` instead of `typedef struct { … } Game_t`. Doing that that for the `Game_t` and `Player_t` types fixed the errors and allowed me to compile and play umoria.

Fixes #45