### PR TITLE
Fix array-bounds warning

### DIFF
--- a/src/game_save.cpp
+++ b/src/game_save.cpp
@@ -807,7 +807,7 @@ bool loadGame(bool &generate) {
             count = rdByte();
             char_tmp = rdByte();
             for (int i = count; i > 0; i--) {
-                if (tile >= &dg.floor[MAX_HEIGHT][0]) {
+                if (tile >= &dg.floor[MAX_HEIGHT - 1][0]) {
                     goto error;
                 }
                 tile->feature_id = (uint8_t)(char_tmp & 0xF);


### PR DESCRIPTION
Seen in GCC 11.2:

```
/tmp/git/umoria/src/game_save.cpp: In function 'bool loadGame(bool&)':
/tmp/git/umoria/src/game_save.cpp:810:29: error: array subscript 66 is above array bounds of 'Tile_t [66][198]' [-Werror=array-bounds]
  810 |                 if (tile >= &dg.floor[MAX_HEIGHT][0]) {
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~
In file included from /tmp/git/umoria/src/headers.h:59,
                 from /tmp/git/umoria/src/game_save.cpp:8:
/tmp/git/umoria/src/dungeon.h:55:12: note: while referencing 'Dungeon_t::floor'
   55 |     Tile_t floor[MAX_HEIGHT][MAX_WIDTH];
      |            ^~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [CMakeFiles/umoria.dir/build.make:370: CMakeFiles/umoria.dir/src/game_save.cpp.o] Error 1
```