### PR TITLE
Add umoria.spec, fix wizard.cpp compile error

### DIFF
--- a/src/wizard.cpp
+++ b/src/wizard.cpp
@@ -380,7 +380,7 @@ static bool wizardRequestObjectId(int &id, const std::string &label, int start_i
 
 // Simplified wizard routine for creating an object
 void wizardGenerateObject() {
-    int id;
+    int id=0;
     if (!wizardRequestObjectId(id, "Dungeon/Store object", 0, 366)) {
         return;
     }

--- a/umoria.spec
+++ b/umoria.spec
@@ -1,0 +1,70 @@
+%global debug_package %{nil}
+
+%if 0%{?suse_version} || 0%{?rhel} == 8
+%define __builddir %{_vpath_builddir}
+%endif
+
+Name:           umoria
+Version:        5.7.15
+Release:        1%{?dist}
+Summary:    	Umoria %{version}
+
+License:        GPL-3.0
+URL:            https://umoria.org 
+Source0:        umoria-%{version}.tar.gz
+
+BuildRequires:  ncurses-devel gcc-c++ cmake
+Requires:       ncurses-libs
+
+
+%description
+The Dungeons of Moria is a single player dungeon simulation originally written by Robert Alan Koeneke, with its first public release in 1983.
+The game was originally developed using VMS Pascal before being ported to the C language by James E. Wilson in 1988, and released a Umoria.
+
+
+%prep
+%autosetup
+
+
+%build
+
+%if 0%{?rhel} == 8
+mkdir %{_vpath_builddir} && (cd %{_vpath_builddir}; %cmake ..; %cmake_build )
+%else
+%cmake
+%cmake_build
+%endif
+
+
+%install
+mkdir -p $RPM_BUILD_ROOT/%{_bindir}
+cp %{_vpath_builddir}/umoria/umoria $RPM_BUILD_ROOT/%{_bindir}/umoria.bin
+mkdir -p $RPM_BUILD_ROOT/%{_datadir}/games/umoria
+cp -R %{_vpath_builddir}/umoria/data $RPM_BUILD_ROOT/%{_datadir}/games/umoria
+
+cat << EOF > $RPM_BUILD_ROOT/%{_bindir}/umoria
+#!/bin/sh
+CONFDIR=~/.config/umoria
+DATADIR=%{_datadir}/games/umoria/data
+BIN=%{_bindir}/umoria.bin
+[ ! -d \$CONFDIR ] && mkdir -p \$CONFDIR && ln -s \$DATADIR \$CONFDIR/data
+[ ! -f \$CONFDIR/scores.dat ] && touch \$CONFDIR/scores.dat
+(cd \$CONFDIR; \$BIN \$@)
+EOF
+
+chmod +x $RPM_BUILD_ROOT/%{_bindir}/umoria
+
+%postun
+echo "Please remove each user's ~/.config/umoria manually, if you need."
+
+%files
+%{_bindir}/umoria*
+%{_datadir}/games/umoria/data/*
+%license LICENSE
+%doc *.md AUTHORS
+
+
+
+%changelog
+* Sat Feb 18 2023 Shiro Hara <white@vx-xv.com>
+- Add .spec file


### PR DESCRIPTION
## About umoria.spec
I made a umoria.spec file to make .rpm for Fedora, RHEL, and OpenSUSE, etc.

1.  About running umoria in this .rpm installation
Umoria originally keeps files in each user's environment and does not install binaries under /usr etc., I think.
So I decide to make ~/.config/umoria and keep a save file, score file into it.
/usr/bin/umoria is a shell script to run umoria in ~/.config/umoria.

2. About distributing .rpm
I also started to distribute .rpm on the Fedora copr.
Please see the below URL for the details.
https://copr.fedorainfracloud.org/coprs/whitehara/umoria/

## About fixing wizard.cpp compile error
On some architectures, wizard.cpp becomes compile error because the "int id" is not initialized. So I fixed it.

If you find any problems in this pull request, please feel free to ask me.