### PR TITLE
Update umoria.spec, add compile option -Wno-format-truncation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,9 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(cxx_warnings "${cxx_warnings} -Wno-format-overflow")
 endif()
 
+# Ignore string truncation warnings for using snprintf
+set(cxx_warnings "${cxx_warnings} -Wno-format-truncation")
+
 #
 # Set the flags and warnings for the debug/release builds
 #

--- a/umoria.spec
+++ b/umoria.spec
@@ -6,7 +6,7 @@
 
 Name:           umoria
 Version:        5.7.15
-Release:        1%{?dist}
+Release:        3%{?dist}
 Summary:    	Umoria %{version}
 
 License:        GPL-3.0
@@ -41,6 +41,8 @@ mkdir -p $RPM_BUILD_ROOT/%{_bindir}
 cp %{_vpath_builddir}/umoria/umoria $RPM_BUILD_ROOT/%{_bindir}/umoria.bin
 mkdir -p $RPM_BUILD_ROOT/%{_datadir}/games/umoria
 cp -R %{_vpath_builddir}/umoria/data $RPM_BUILD_ROOT/%{_datadir}/games/umoria
+mkdir -p $RPM_BUILD_ROOT/%{_docdir}/umoria/historical
+cp historical/* $RPM_BUILD_ROOT/%{_docdir}/umoria/historical
 
 cat << EOF > $RPM_BUILD_ROOT/%{_bindir}/umoria
 #!/bin/sh
@@ -60,11 +62,18 @@ echo "Please remove each user's ~/.config/umoria manually, if you need."
 %files
 %{_bindir}/umoria*
 %{_datadir}/games/umoria/data/*
+%{_docdir}/umoria/historical/*
 %license LICENSE
 %doc *.md AUTHORS
 
 
 
 %changelog
-* Sat Feb 18 2023 Shiro Hara <white@vx-xv.com>
+* Sat Dec 30 2023 Shiro Hara <white@vx-xv.com> - 5.7.15-3
+- Enable roguelike keys via the CLI
+
+* Sat Jul 1 2023 Shiro Hara <white@vx-xv.com> - 5.7.15-2
+- Add files in "historical" to doc (Thanks, Justin Koh)
+
+* Sat Feb 18 2023 Shiro Hara <white@vx-xv.com> -5.7.15-1
 - Add .spec file


### PR DESCRIPTION
- Updated umoria.spec
- Newest RPMs are provided at Copr with the historical documents. See https://copr.fedorainfracloud.org/coprs/whitehara/umoria/
- There are some warnings about truncating strings at the codes of using "snprintf", and these will be causes of the compile errors because there is "-Werror" for building. So disabled the warnings with "-Wno-format-truncation"