### PR TITLE
Fix issue #74 (lock picking skill)

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1229,8 +1229,7 @@ static void playerAttackMonster(Coord_t coord) {
 static int16_t playerLockPickingSkill() {
     int16_t skill = py.misc.disarm;
 
-    skill += 2;
-    skill *= playerDisarmAdjustment();
+    skill += 2 * playerDisarmAdjustment();
     skill += playerStatAdjustmentWisdomIntelligence(PlayerAttr::A_INT);
     skill += class_level_adj[py.misc.class_id][PlayerClassLevelAdj::DISARM] * py.misc.level / 3;
 


### PR DESCRIPTION
The lock picking calculation got broken in ccfa74783ad67eb3276ff3eca0f2509599012d33 when the order of an addition and a multiplication accidentally got switched. This patch fixes the calculation to be the same as before that commit, and the same as what is shown on the character status screen.