### PR TITLE
src/ui_io.cpp: fix build against clang-19

### DIFF
--- a/src/ui_io.cpp
+++ b/src/ui_io.cpp
@@ -533,14 +533,15 @@ bool checkForNonBlockingKeyPress(int microseconds) {
 #else
     struct timeval tbuf {};
     int ch;
-    int smask;
+    fd_set smask;
 
     // Return true if a read on descriptor 1 will not block.
     tbuf.tv_sec = 0;
     tbuf.tv_usec = microseconds;
 
-    smask = 1; // i.e. (1 << 0)
-    if (select(1, (fd_set *) &smask, (fd_set *) nullptr, (fd_set *) nullptr, &tbuf) == 1) {
+    FD_ZERO(&smask);
+    FD_SET(STDIN_FILENO, &smask);
+    if (select(1, &smask, (fd_set *) nullptr, (fd_set *) nullptr, &tbuf) == 1) {
         ch = getch();
         // check for EOF errors here, select sometimes works even when EOF
         if (ch == -1) {


### PR DESCRIPTION
Withot the change the build fails on clang-19 as:

    source/src/ui_io.cpp:543:19:
      error: cast from 'int *' to 'fd_set *' increases required alignment from 4 to 8 [-Werror,-Wcast-align]
      543 |     if (select(1, (fd_set *) &smask, (fd_set *) nullptr, (fd_set *) nullptr, &tbuf) == 1) {
          |                   ^~~~~~~~~~~~~~~~~

The fix is to use `fd_set` type to initialize select parameter.