### PR TITLE
src/ui.cpp: fix startup crash on clang

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -155,7 +155,7 @@ void statsAsString(uint8_t stat, char *stat_string) {
 
 // Print character stat in given row, column -RAK-
 void displayCharacterStats(int stat) {
-    char text[7];
+    char text[MORIA_MESSAGE_SIZE];
     statsAsString(py.stats.used[stat], text);
     putString(stat_names[stat], Coord_t{6 + stat, STAT_COLUMN});
     putString(text, Coord_t{6 + stat, STAT_COLUMN + 6});


### PR DESCRIPTION
Without the change `umoria` crashes at start as:

    (gdb) bt
    #0  __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at pthread_kill.c:44
    #1  0x00007fceb6bb2b03 in __pthread_kill_internal (signo=6, threadid=<optimized out>) at pthread_kill.c:78
    #2  0x00007fceb6b60576 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
    #3  0x00007fceb6b48935 in __GI_abort () at abort.c:79
    #4  0x00007fceb6b497f3 in __libc_message_impl (fmt=fmt@entry=0x7fceb6cce175 "*** %s ***: terminated\n") at ../sysdeps/posix/libc_fatal.c:132
    #5  0x00007fceb6c3cd19 in __GI___fortify_fail (msg=msg@entry=0x7fceb6cce15c "buffer overflow detected") at fortify_fail.c:24
    #6  0x00007fceb6c3c634 in __GI___chk_fail () at chk_fail.c:28
    #7  0x00007fceb6c3e5f9 in ___vsnprintf_chk (s=<optimized out>, maxlen=<optimized out>, flag=<optimized out>, slen=<optimized out>, format=<optimized out>, ap=<optimized out>) at vsnprintf_chk.c:28
    #8  0x000055be9721cbb2 in snprintf(char*, unsigned long pass_object_size1, char const*, ...) (__s=0x3ce914 <error: Cannot access memory at address 0x3ce914>, __n=3991828,
        __fmt=0x8 <error: Cannot access memory at address 0x8>) at /nix/store/932dj5qwfzck90mnvqpd1f9hjqznaqdj-glibc-2.40-36-dev/include/bits/stdio2.h:80
    #9  0x000055be9721c277 in statsAsString (stat_string=0x7ffe41b20cf0 "?", stat=<optimized out>) at /build/source/src/ui.cpp:148
    #10 displayCharacterStats (stat=0) at /build/source/src/ui.cpp:159
    #11 printCharacterStatsBlock () at /build/source/src/ui.cpp:415
    #12 0x000055be971eab36 in startMoria (seed=seed@entry=0, start_new_game=<optimized out>, roguelike_keys=<optimized out>) at /build/source/src/game_run.cpp:126
    #13 0x000055be971dc40e in main (argc=<optimized out>, argv=<optimized out>) at /build/source/src/main.cpp:104

It's caused by `_FORTIFY_SOURCE=3` define which makes sue that buffers passed to `snprintf(b, b_len, ...)` are know to have enough `b_len` space.

In our case `snprintf()` assumes 80-byte buffer length, but passed buffer is just 7 bytes long.

As a simple fix I increased input buffer to 80 bytes.