### PR TITLE
Fix complication on Apple Silicon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,9 +66,6 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(cxx_warnings "${cxx_warnings} -Wno-format-overflow")
 endif()
 
-# Ignore string truncation warnings for using snprintf
-set(cxx_warnings "${cxx_warnings} -Wno-format-truncation")
-
 #
 # Set the flags and warnings for the debug/release builds
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ set(cxx_warnings "${cxx_warnings} -Wswitch-default")
 set(cxx_warnings "${cxx_warnings} -Wswitch-enum")
 set(cxx_warnings "${cxx_warnings} -Wunreachable-code")
 set(cxx_warnings "${cxx_warnings} -Wwrite-strings")
+set(cxx_warnings "${cxx_warnings} -Wno-deprecated-declarations")
 
 # Some very strict warnings, that will be nice to use, but require some hefty refactoring
 # set(cxx_warnings "${cxx_warnings} -Wcast-qual")


### PR DESCRIPTION
These changes fix compilation errors on Apple Silicon:

1. **Enable `-Wno-deprecated-declarations` compilation flag**
2. **Remove `-Wno-format-truncation` compiler option** (this compiler option is not compatible with the default compiler on macOS 14.5, but this option is no longer necessary since the codebase has previously been updated to use `snprintf` anyway)